### PR TITLE
fix(deps): 7 security fixes in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,11 +110,11 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.16",
-    "eslint": "^8.57.1",
+    "eslint": "^9.26.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^9.1.7",
-    "postcss": "^8.4.32",
+    "postcss": "^8.5.10",
     "prettier": "^3.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -169,6 +169,6 @@
     "react-router-dom": "^7.7.0",
     "tailwind-merge": "^2.6.0",
     "three": "^0.180.0",
-    "vite": "^7.0.5"
+    "vite": "^7.0.6"
   }
 }


### PR DESCRIPTION
## Security Fixes

**File:** `package.json`

| Severity | Package | CVE | Vulnerability | Version |
|---|---|---|---|---|
| ![moderate](https://img.shields.io/badge/severity-moderate-yellow) | `vite` | CVE-2026-39365 | Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling | `7.0.5` → `7.0.6` |
| ![high](https://img.shields.io/badge/severity-high-orange) | `vite` | CVE-2026-39363 | Vite Vulnerable to Arbitrary File Read via Vite Dev Server WebSocket | `7.0.5` → `7.0.6` |
| ![moderate](https://img.shields.io/badge/severity-moderate-yellow) | `vite` | CVE-2025-62522 | vite allows server.fs.deny bypass via backslash on Windows | `7.0.5` → `7.0.6` |
| ![low](https://img.shields.io/badge/severity-low-blue) | `vite` | CVE-2025-58751 | Vite middleware may serve files starting with the same name with the public directory | `7.0.5` → `7.0.6` |
| ![low](https://img.shields.io/badge/severity-low-blue) | `vite` | CVE-2025-58752 | Vite's `server.fs` settings were not applied to HTML files | `7.0.5` → `7.0.6` |
| ![moderate](https://img.shields.io/badge/severity-moderate-yellow) | `eslint` | CVE-2025-50537 | Withdrawn Advisory: eslint has a Stack Overflow when serializing objects with circular references | `8.57.1` → `9.26.0` |
| ![moderate](https://img.shields.io/badge/severity-moderate-yellow) | `postcss` | CVE-2026-41305 | PostCSS has XSS via Unescaped </style> in its CSS Stringify Output | `8.4.32` → `8.5.10` |

**Sources:** github-advisory


---
*Automated fix by nudge*